### PR TITLE
Dont override prometheus gateway path if already set

### DIFF
--- a/src/metrics/github.ts
+++ b/src/metrics/github.ts
@@ -25,8 +25,10 @@ export function getMetricsUrl() {
   const parsed = new URL(gateway);
   const type = process.env.INPUT_GATEWAYTYPE;
   if (type === "prometheus") {
-    const labels = getLabels();
-    parsed.pathname = `/metrics/job/${labels.job}/workflow/${labels.workflow}`;
+    if (!parsed.pathname || parsed.pathname === "" || parsed.pathname === "/" || parsed.pathname === "/metrics") {
+      const labels = getLabels();
+      parsed.pathname = `/metrics/job/${labels.job}/workflow/${labels.workflow}`;
+    }
   } else if (parsed.pathname !== "/metrics") {
     parsed.pathname = "/metrics";
   }


### PR DESCRIPTION
If the prometheus gateway path name is not an empty string, "/" or "/metrics", it will remain unchanged so the user can set custom tags.

Fixes #5